### PR TITLE
Opt area

### DIFF
--- a/info.yaml
+++ b/info.yaml
@@ -9,7 +9,7 @@ project:
   clock_hz:     25000000           # Clock frequency in Hz (or 0 if not applicable)
 
   # How many tiles your design occupies? A single tile is about 167x108 uM.
-  tiles: "2x2"          # Valid values: 1x1, 1x2, 2x2, 3x2, 4x2, 6x2 or 8x2
+  tiles: "1x2"          # Valid values: 1x1, 1x2, 2x2, 3x2, 4x2, 6x2 or 8x2
 
   # Your top module name must start with "tt_um_". Make it unique by including your github username:
   top_module:  "tt_um_RoyTr16"

--- a/src/board_rw.v
+++ b/src/board_rw.v
@@ -2,8 +2,8 @@ module board_rw (
     clk,
     rst_n,
     enable,
-    w_row,
-    w_col,
+    w_drop_row,
+    w_drop_col,
     data_in,
     write,
     winning_row,
@@ -11,6 +11,7 @@ module board_rw (
     w_winning_pieces,
     r_row,
     r_col,
+    winner,
     data_out,
     winning_out
 );
@@ -21,8 +22,8 @@ module board_rw (
     input clk;
     input rst_n;
     input enable;
-    input [2:0] w_row;
-    input [2:0] w_col;
+    input [2:0] w_drop_row;
+    input [2:0] w_drop_col;
     input [1:0] data_in;
     input write;
     input [2:0] winning_row;
@@ -30,65 +31,43 @@ module board_rw (
     input w_winning_pieces;
     input [2:0] r_row;
     input [2:0] r_col;
+    input [1:0] winner;
     output [1:0] data_out;
     output winning_out;
 
     // 8x8 board
     reg [ROWS*COLS*2-1:0] board;
-    reg [ROWS*COLS-1:0] winning_pieces;
 
-    // Counter for sequential synchronous reset of board
-    reg  [6:0] rst_board_counter;
-    wire rst_board_done;
-
-    // Reset counter for board
-	wire [2:0] rst_col_counter;
-	wire [2:0] rst_row_counter;
-
-    // Divide the board counter into row and column counters
-    assign rst_col_counter = rst_board_counter[2:0];
-	assign rst_row_counter = rst_board_counter[5:3];
-	assign rst_board_done = rst_board_counter[6];
+    wire [1:0] r_piece;
+    wire write_to_board;
+    wire [1:0] w_piece;
+    wire [2:0] w_row;
+    wire [2:0] w_col;
 
     // Read from board
-    assign data_out = board[(8*r_row + r_col)*2 +: 2];
-    assign winning_out = winning_pieces[(8*r_row + r_col)];
+    assign r_piece = board[(8*r_row + r_col)*2 +: 2];
+    assign write_to_board = enable & (write | w_winning_pieces);
+    assign w_piece = w_winning_pieces ? 2'b11 : data_in;
+    assign w_row   = w_winning_pieces ? winning_row : w_drop_row;
+    assign w_col   = w_winning_pieces ? winning_col : w_drop_col;
 
-	// Counter for sequential synchronous reset of board counter
-	always @(posedge clk or negedge rst_n)
-	begin
-		if (!rst_n)
-			rst_board_counter <= 7'd0;
-		else
-		begin
-			if (rst_board_counter[6] == 1'b0)
-				rst_board_counter <= rst_board_counter + 7'd1;
-		end
-	end
+    assign data_out    = winner  == 2'b00 ? r_piece :
+                         r_piece == 2'b11 ? winner :
+                         r_piece;
+
+    assign winning_out = r_piece == 2'b11;
 
     // Sequential write to board
-    always @(posedge clk)
-    begin
-        // Reset board
-        if (!rst_board_done)
-            board[(8*rst_row_counter + rst_col_counter)*2 +: 2] <= 2'b00;
-        else
-        // Write to board
-        if (enable & write)
-        begin
-            board[(8*w_row + w_col)*2 +: 2] <= data_in;
-        end
-    end
-
-    // Sequential write to winning pieces
     always @(posedge clk or negedge rst_n)
     begin
-        if (!rst_n)
-            winning_pieces <= 64'd0;
+        if (~rst_n)
+            board <= 0;
         else
+        if (enable)
+        // Write to board
         begin
-            if (w_winning_pieces == 1'b1)
-                winning_pieces[(8*winning_row + winning_col)] <= 1'b1;
+            if (write_to_board)
+                board[(8*w_row + w_col)*2 +: 2] <= w_piece;
         end
     end
 

--- a/src/btn_debounce.v
+++ b/src/btn_debounce.v
@@ -1,16 +1,16 @@
-module btn_debounce #(CLKS_TO_WAIT=25000) (
+module btn_debounce #(CLKS_TO_WAIT=25000, N_BUTTONS=3) (
   clk,
   rst_n,
   e_debug,
-  btn_in,
-  btn_out
+  btns_in,
+  btns_out
 );
 
-  input clk;
-  input rst_n;
-  input e_debug;
-  input btn_in;
-  output btn_out;
+  input  clk;
+  input  rst_n;
+  input  e_debug;
+  input  [N_BUTTONS-1:0] btns_in;
+  output [N_BUTTONS-1:0] btns_out;
 
   localparam WIDTH = $clog2(CLKS_TO_WAIT)+1;
 
@@ -18,28 +18,31 @@ module btn_debounce #(CLKS_TO_WAIT=25000) (
   localparam ST_COUNTING = 1'b1;
 
   reg [WIDTH-1:0] debounce_counter;  // 18-bit counter for 10 ms debounce time at 25 MHz clock
-  reg button_sync_0;
-  reg button_sync_1;
-  reg debounced;
+  reg [N_BUTTONS-1:0] button_sync_0;
+  reg [N_BUTTONS-1:0] button_sync_1;
+  reg [N_BUTTONS-1:0] button_sync_2;
+  reg [N_BUTTONS-1:0] debounced;
 
   reg  debounce_state;
   wire btn_pushed;
 
-  assign btn_out = e_debug ? btn_in : debounced;
-  assign btn_pushed = ~button_sync_0 & button_sync_1;
+  assign btns_out = e_debug ? btns_in : debounced;
+  assign btn_pushed = button_sync_2 == {N_BUTTONS{1'b1}} & button_sync_1 != {N_BUTTONS{1'b1}};
 
   // Synchronize the button input to the clock domain to avoid metastability
   always @(posedge clk or negedge rst_n)
   begin
     if (~rst_n)
     begin
-      button_sync_0 <= 1'b1;
-      button_sync_1 <= 1'b1;
+      button_sync_0 <= {N_BUTTONS{1'b1}};
+      button_sync_1 <= {N_BUTTONS{1'b1}};
+      button_sync_2 <= {N_BUTTONS{1'b1}};
     end
     else
     begin
-      button_sync_0 <= btn_in;
+      button_sync_0 <= btns_in;
       button_sync_1 <= button_sync_0;
+      button_sync_2 <= button_sync_1;
     end
   end
 
@@ -49,7 +52,7 @@ module btn_debounce #(CLKS_TO_WAIT=25000) (
     if (~rst_n)
     begin
       debounce_counter <= {WIDTH{1'b0}};
-      debounced <= 1'b1;
+      debounced <= {N_BUTTONS{1'b1}};
     end
     else
     begin
@@ -59,17 +62,17 @@ module btn_debounce #(CLKS_TO_WAIT=25000) (
           if (btn_pushed)
           begin
             debounce_state <= ST_COUNTING;
-            debounced <= 1'b0;
+            debounced <= button_sync_1;
           end
           else
           begin
             debounce_state <= ST_IDLE;
-            debounced <= 1'b1;
+            debounced <= {N_BUTTONS{1'b1}};
           end
         end
         ST_COUNTING:
         begin
-          debounced <= 1'b1;
+          debounced <= {N_BUTTONS{1'b1}};
           debounce_counter <= debounce_counter + 1;
           if (debounce_counter == CLKS_TO_WAIT)
             debounce_state <= ST_IDLE;

--- a/src/config.json
+++ b/src/config.json
@@ -13,7 +13,7 @@
 
   "//": "PL_TARGET_DENSITY_PCT - You can increase this if Global Placement fails with error GPL-0302.",
   "//": "Users have reported that values up to 80 worked well for them.",
-  "PL_TARGET_DENSITY_PCT": 75,
+  "PL_TARGET_DENSITY_PCT": 85,
 
   "//": "CLOCK_PERIOD - Increase this in case you are getting setup time violations.",
   "//": "The value is in nanoseconds, so 20ns == 50MHz.",

--- a/src/config.json
+++ b/src/config.json
@@ -13,7 +13,7 @@
 
   "//": "PL_TARGET_DENSITY_PCT - You can increase this if Global Placement fails with error GPL-0302.",
   "//": "Users have reported that values up to 80 worked well for them.",
-  "PL_TARGET_DENSITY_PCT": 85,
+  "PL_TARGET_DENSITY_PCT": 89,
 
   "//": "CLOCK_PERIOD - Increase this in case you are getting setup time violations.",
   "//": "The value is in nanoseconds, so 20ns == 50MHz.",

--- a/src/connect_four.v
+++ b/src/connect_four.v
@@ -64,9 +64,6 @@ module connect_four (
 	wire [1:0] next_player;
 	wire drop_allowed;
 
-	// Counter for sequential synchronous reset of column counter
-	reg  [COL_BITS:0] rst_column_counter;
-
 	// Synchronizers for input buttons
 	reg [2:0] drop_piece_sync;
 	reg [2:0] move_right_sync;
@@ -127,17 +124,6 @@ module connect_four (
 	assign mem_r_row = current_state == ST_CHECKING_VICTORY ? victory_checker_r_row : top_row_read;
 	assign mem_r_col = current_state == ST_CHECKING_VICTORY ? victory_checker_r_col : top_col_read;
 
-	// Counter for sequential synchronous reset of column counter
-	always @(posedge clk or negedge rst_n)
-	begin
-		if (!rst_n)
-			rst_column_counter <= {COL_BITS+1{1'b0}};
-		else
-		begin
-			if (rst_column_counter[COL_BITS] == 1'b0)
-				rst_column_counter <= rst_column_counter + {{COL_BITS{1'b0}}, 1'b1};
-		end
-	end
 
 	// Synchronizers to detect rising edge of input from user
 	always @(posedge clk or negedge rst_n)
@@ -167,11 +153,17 @@ module connect_four (
 			write_to_board <= 1'b0;
 			start_game_sound <= 1'b1;
 			game_sound_type <= SOUND_TYPE_START;
+
+			column_counters[0] <= 4'b0000;
+			column_counters[1] <= 4'b0000;
+			column_counters[2] <= 4'b0000;
+			column_counters[3] <= 4'b0000;
+			column_counters[4] <= 4'b0000;
+			column_counters[5] <= 4'b0000;
+			column_counters[6] <= 4'b0000;
+			column_counters[7] <= 4'b0000;
 		end
 		else
-		    if (rst_column_counter[COL_BITS] == 1'b0)
-            	column_counters[rst_column_counter[2:0]] <= {ROW_BITS+1{1'b0}};
-			else
 			case (current_state)
 				ST_IDLE:
 				begin
@@ -268,8 +260,8 @@ module connect_four (
 		.clk(clk),
 		.rst_n(rst_n),
 		.enable(1'b1),
-		.w_row(current_row),
-		.w_col(current_col),
+		.w_drop_row(current_row),
+		.w_drop_col(current_col),
 		.data_in(current_player),
 		.write(write_to_board),
 		.winning_row(winning_row),
@@ -277,6 +269,7 @@ module connect_four (
 		.w_winning_pieces(w_winning_pieces),
 		.r_row(mem_r_row),
 		.r_col(mem_r_col),
+		.winner(winner),
 		.data_out(mem_data_out),
 		.winning_out(winning_out)
 	);

--- a/src/connect_four.v
+++ b/src/connect_four.v
@@ -64,16 +64,6 @@ module connect_four (
 	wire [1:0] next_player;
 	wire drop_allowed;
 
-	// Synchronizers for input buttons
-	reg [2:0] drop_piece_sync;
-	reg [2:0] move_right_sync;
-	reg [2:0] move_left_sync;
-	wire rising_drop_piece;
-	wire rising_move_right;
-	wire rising_move_left;
-	wire move_to_right;
-	wire move_to_left;
-
 	// State machines
 	reg [1:0] current_state;
 
@@ -99,7 +89,7 @@ module connect_four (
 	reg start_game_sound;
 
 	// Check which row to drop the piece in
-    assign row_to_drop = column_counters[current_col];
+  assign row_to_drop = column_counters[current_col];
 	assign drop_allowed = row_to_drop[ROW_BITS] == 1'b0;
 	assign current_row = row_to_drop[ROW_BITS-1:0];
 
@@ -113,34 +103,10 @@ module connect_four (
 	assign next_col_left = (current_col == 0 ? LAST_COL : current_col - 3'b001);
 	assign next_player = (current_player == PLAYER1 ? PLAYER2 : PLAYER1);
 
-	// Input button synchronizers
-	assign rising_drop_piece = drop_piece_sync[2] & ~drop_piece_sync[1];
-	assign rising_move_right = move_right_sync[2] & ~move_right_sync[1];
-	assign rising_move_left  = move_left_sync[2] & ~move_left_sync[1];
-	assign move_to_right     = rising_move_right & ~rising_move_left;
-	assign move_to_left      = rising_move_left & ~rising_move_right;
-
 	// Read from board memory
 	assign mem_r_row = current_state == ST_CHECKING_VICTORY ? victory_checker_r_row : top_row_read;
 	assign mem_r_col = current_state == ST_CHECKING_VICTORY ? victory_checker_r_col : top_col_read;
 
-
-	// Synchronizers to detect rising edge of input from user
-	always @(posedge clk or negedge rst_n)
-	begin
-		if (!rst_n)
-		begin
-			drop_piece_sync <= 3'b111;
-			move_right_sync <= 3'b111;
-			move_left_sync  <= 3'b111;
-		end
-		else
-		begin
-			drop_piece_sync[2:0] <= {drop_piece_sync[1:0], drop_piece};
-			move_right_sync[2:0] <= {move_right_sync[1:0], move_right};
-			move_left_sync[2:0]  <= {move_left_sync[1:0], move_left};
-		end
-	end
 
 	// State Machine to control the game
 	always @(posedge clk or negedge rst_n)
@@ -167,7 +133,7 @@ module connect_four (
 			case (current_state)
 				ST_IDLE:
 				begin
-					if (rising_drop_piece)
+					if (!drop_piece)
 					begin
 						if (drop_allowed)
 						begin
@@ -231,9 +197,9 @@ module connect_four (
 			current_col <= 3'b000;
 		else if (current_state == ST_IDLE)
 		begin
-			if (move_to_right)
+			if (!move_right)
 				current_col <= next_col_right;
-			else if (move_to_left)
+			else if (!move_left)
 				current_col <= next_col_left;
 		end
 	end

--- a/src/tt_um_RoyTr16.v
+++ b/src/tt_um_RoyTr16.v
@@ -16,7 +16,7 @@ module tt_um_RoyTr16 (
     input  wire       rst_n      // reset_n - low to reset
 );
 
-   // All output pins must be assigned. If not used, assign to 0.
+  // All output pins must be assigned. If not used, assign to 0.
 
   // List all unused inputs to prevent warnings
   wire _unused = &{ena, ui_in [6:3], 1'b0};
@@ -90,28 +90,15 @@ module tt_um_RoyTr16 (
     .d_piece_data    (d_piece_data)      // Debug piece data
   );
 
-  btn_debounce #(.CLKS_TO_WAIT(2500000)) btn_right_debounce_inst (
+  btn_debounce #(
+    .CLKS_TO_WAIT(2500000),
+    .N_BUTTONS(3)
+  ) btn_right_debounce_inst (
     .clk      (clk),
     .rst_n    (rst_n),
     .e_debug  (e_debug),
-    .btn_in   (move_right),
-    .btn_out  (move_right_debounced)
-  );
-
-  btn_debounce #(.CLKS_TO_WAIT(2500000)) btn_left_debounce_inst (
-    .clk      (clk),
-    .rst_n    (rst_n),
-    .e_debug  (e_debug),
-    .btn_in   (move_left),
-    .btn_out  (move_left_debounced)
-  );
-
-  btn_debounce #(.CLKS_TO_WAIT(2500000)) btn_drop_debounce_inst (
-    .clk      (clk),
-    .rst_n    (rst_n),
-    .e_debug  (e_debug),
-    .btn_in   (drop_piece),
-    .btn_out  (drop_piece_debounced)
+    .btns_in   ({move_right, move_left, drop_piece}),
+    .btns_out  ({move_right_debounced, move_left_debounced, drop_piece_debounced})
   );
 
 	debug_controller debug_ctrl (


### PR DESCRIPTION
Main optimizations:

- Using the 2'b11 state in the board vector to mark a winning piece to flash instead of the extra winning_pieces vector.
- Reverting the sequential resets back to normal combinational resets, that seemed to greatly reduce logic cost
- Using one debounce counter for all 3 buttons instead of one counter for each button
- Heavily experimenting with the density and stretching the limit, going with 89